### PR TITLE
Some fixes to problems we experienced in production

### DIFF
--- a/zerokspot/recipe/git/__init__.py
+++ b/zerokspot/recipe/git/__init__.py
@@ -189,7 +189,7 @@ class Recipe(object):
             args = ('--recursive', from_, to,) if self.recursive \
                                                else (from_, to,)
             git('clone', args, "Couldn't clone %s into %s" % (
-                    from_, to, ))
+                    from_, to, ), verbose=True)
             os.chdir(to)
 
             if not '[branch "%s"]' % self.branch in open(os.path.join('.git', 'config')).read():
@@ -241,7 +241,7 @@ class Recipe(object):
         try:
             os.chdir(path)
             git('pull', ('origin', self.branch, ),
-                    "Failed to update repository")
+                    "Failed to update repository", verbose=True)
         finally:
             os.chdir(self.root_dir)
 

--- a/zerokspot/recipe/git/__init__.py
+++ b/zerokspot/recipe/git/__init__.py
@@ -192,13 +192,12 @@ class Recipe(object):
                     from_, to, ))
             os.chdir(to)
 
-            if self.branch != 'master':
-                if not '[branch "%s"]' % self.branch in open(os.path.join('.git', 'config')).read():
-                    git('branch', ('--track', self.branch, 'origin/%s' % self.branch),
-                        "Failed to set up to track remote branch", verbose=True)
-                if not "ref: refs/heads/%s" % self.branch in open(os.path.join('.git', 'HEAD')).read():
-                    git('checkout', (self.branch,), "Failed to switch to branch '%s'" % self.branch,
-                        ignore_errnos=[128])
+            if not '[branch "%s"]' % self.branch in open(os.path.join('.git', 'config')).read():
+                git('branch', ('--track', self.branch, 'origin/%s' % self.branch),
+                    "Failed to set up to track remote branch", verbose=True)
+            if not "ref: refs/heads/%s" % self.branch in open(os.path.join('.git', 'HEAD')).read():
+                git('checkout', (self.branch,), "Failed to switch to branch '%s'" % self.branch,
+                    ignore_errnos=[128])
 
             if self.rev is not None:
                 git('checkout', (self.rev, ), "Failed to checkout revision")


### PR DESCRIPTION
Hey there,

we had two hard-to-debug problems when using `zerokspot.recipe.git` in production inside a buildout which pulls a large number of repositories from our GitHub:FI installation. After finally tracking them down, here are the fixes:

reg. ef003aa8: This fixes a problem when `zerokspot.recipe.git` assumed the default branch of a repository always is "master". This isn't the case with all repositories (we use some repositories where the default branch is set to "develop"). This makes `zerokspot.recipe.git` fail each second run when switching between branches (can't remember the exact error message).

reg. fc1805e6: With some repositories, we got this nasty error on clone- and pull-operations::

```
fatal: The remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
```

We couldn't find the root-cause, but the problem could be resolved by always passing the "verbose" option to clone- and pull-operations.

We're hoping you can merge these changes and issue a new 0.6.1 release on PyPI, even though you don't actively maintain this package anymore.

Thanks in advance!

Cheers,
Andreas.

P.S.: Please let us know if we should take over maintenance.
